### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 Version 1.1.0 *(2015-11-24)*
 ----------------------------
 * change the realization of RoundView without ondraw since press effect is not very good in some devices.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#FlycoRoundView
+# FlycoRoundView
 A library helps Android built-in views easy and convenient to set round rectangle background and accordingly related shape resources can be reduced.
 一个扩展原生控件支持圆角矩形框背景的库,可以减少相关shape资源文件使用.
-##Demo
+## Demo
 ![](https://github.com/H07000223/FlycoRoundView/blob/master/preview.gif)
 
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -12,7 +12,7 @@ dependencies{
 }
 ```
 
-###Attributes
+### Attributes
 
 |name|format|description|
 |:---:|:---:|:---:|


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
